### PR TITLE
use boxFront metadata for boxArt if supplied

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -304,6 +304,8 @@ function boxArt(data) {
     if (data.assets.boxFront.includes("/header.jpg")) 
       return steamBoxArt(data);
     else {
+      if (data.assets.boxFront != "")
+        return data.assets.boxFront;
       if (data.assets.screenshots[0] != "")
         return data.assets.screenshots[0];
     }


### PR DESCRIPTION
this updates the boxArt utility to use the boxFront metadata for non-steam games if its provided. then it falls back to screenshot
this matches how the steam boxart behaves