### PR TITLE
New "Use posters for grid" setting

### DIFF
--- a/Global/DynamicGridItem.qml
+++ b/Global/DynamicGridItem.qml
@@ -120,6 +120,7 @@ id: root
         Rectangle {
         id: overlay
         
+            active: !modelData.assets.poster
             anchors.fill: parent
             color: screenshot.source == "" ? theme.secondary : "black"
             opacity: screenshot.source == "" ? 1 : selected ? 0.1 : 0.2
@@ -155,6 +156,7 @@ id: root
     Text {
     id: title
 
+        active: !modelData.assets.poster
         text: modelData ? modelData.title : ''
         color: theme.text
         font {

--- a/Global/DynamicGridItem.qml
+++ b/Global/DynamicGridItem.qml
@@ -49,6 +49,7 @@ id: root
 
     property bool selected
     property var gameData: modelData
+    property bool usePoster: settings.UsePostersForGrid === "Yes" && gameData && gameData.assets.poster != ""
 
 
     // In order to use the retropie icons here we need to do a little collection specific hack
@@ -92,7 +93,7 @@ id: root
 
             anchors.fill: parent
             anchors.margins: vpx(2)
-            source: modelData ? modelData.assets.poster || modelData.assets.screenshots[0] || modelData.assets.background || "" : ""
+            source: usePoster ? modelData.assets.poster : modelData ? modelData.assets.screenshots[0] || modelData.assets.background || "" : ""
             fillMode: Image.PreserveAspectCrop
             sourceSize { width: 512; height: 512 }
             smooth: true
@@ -107,12 +108,13 @@ id: root
             anchors.centerIn: parent
             anchors.margins: root.width/10
             property var logoImage: (gameData && gameData.collections.get(0).shortName === "retropie") ? gameData.assets.boxFront : (gameData.collections.get(0).shortName === "steam") ? logo(gameData) : gameData.assets.logo
-            source: modelData ? modelData.assets.poster ? "" : logoImage || "" : ""
+            source: modelData ? logoImage || "" : ""
             sourceSize { width: 400; height: 300 }
             fillMode: Image.PreserveAspectFit
             asynchronous: true
             smooth: true
             scale: selected ? 1.1 : 1
+            visible: !usePoster
             Behavior on scale { NumberAnimation { duration: 300 } }
             z: 10
         }
@@ -122,7 +124,7 @@ id: root
         
             anchors.fill: parent
             color: screenshot.source == "" ? theme.secondary : "black"
-            opacity: modelData.assets.poster ? 0 : screenshot.source == "" ? 1 : selected ? 0.1 : 0.2
+            opacity: screenshot.source == "" ? 1 : usePoster ? selected ? 0 : 0.1 : selected ? 0.1 : 0.2
         }
         
         Rectangle {
@@ -155,7 +157,7 @@ id: root
     Text {
     id: title
 
-        text: modelData && !modelData.assets.poster ? modelData.title : ''
+        text: modelData ? modelData.title : ''
         color: theme.text
         font {
             family: subtitleFont.name

--- a/Global/DynamicGridItem.qml
+++ b/Global/DynamicGridItem.qml
@@ -92,7 +92,7 @@ id: root
 
             anchors.fill: parent
             anchors.margins: vpx(2)
-            source: modelData ? modelData.assets.screenshots[0] || modelData.assets.background || "" : ""
+            source: modelData ? modelData.assets.poster || modelData.assets.screenshots[0] || modelData.assets.background || "" : ""
             fillMode: Image.PreserveAspectCrop
             sourceSize { width: 512; height: 512 }
             smooth: true
@@ -107,7 +107,7 @@ id: root
             anchors.centerIn: parent
             anchors.margins: root.width/10
             property var logoImage: (gameData && gameData.collections.get(0).shortName === "retropie") ? gameData.assets.boxFront : (gameData.collections.get(0).shortName === "steam") ? logo(gameData) : gameData.assets.logo
-            source: modelData ? logoImage || "" : ""
+            source: modelData ? modelData.assets.poster ? "" : logoImage || "" : ""
             sourceSize { width: 400; height: 300 }
             fillMode: Image.PreserveAspectFit
             asynchronous: true

--- a/Global/DynamicGridItem.qml
+++ b/Global/DynamicGridItem.qml
@@ -120,10 +120,9 @@ id: root
         Rectangle {
         id: overlay
         
-            active: !modelData.assets.poster
             anchors.fill: parent
             color: screenshot.source == "" ? theme.secondary : "black"
-            opacity: screenshot.source == "" ? 1 : selected ? 0.1 : 0.2
+            opacity: modelData.assets.poster ? 0 : screenshot.source == "" ? 1 : selected ? 0.1 : 0.2
         }
         
         Rectangle {
@@ -156,8 +155,7 @@ id: root
     Text {
     id: title
 
-        active: !modelData.assets.poster
-        text: modelData ? modelData.title : ''
+        text: modelData && !modelData.assets.poster ? modelData.title : ''
         color: theme.text
         font {
             family: subtitleFont.name

--- a/Settings/SettingsScreen.qml
+++ b/Settings/SettingsScreen.qml
@@ -52,6 +52,10 @@ id: root
             setting: "No,Yes"
         }
         ListElement {
+            settingName: "Use posters for grid"
+            setting: "No,Yes"
+        }
+        ListElement {
             settingName: "Hide button help"
             setting: "Yes,No"
         }

--- a/theme.qml
+++ b/theme.qml
@@ -49,6 +49,7 @@ id: root
             HideButtonHelp:                api.memory.has("Hide button help") ? api.memory.get("Hide button help") : "Yes",
             MouseHover:                    api.memory.has("Enable mouse hover") ? api.memory.get("Enable mouse hover") : "No",
             AlwaysShowTitles:              api.memory.has("Always show titles") ? api.memory.get("Always show titles") : "No",
+            UsePostersForGrid:             api.memory.has("Use posters for grid") ? api.memory.get("Use posters for grid") : "No",
             AnimateHighlight:              api.memory.has("Animate highlight") ? api.memory.get("Animate highlight") : "Yes",
             AllowVideoPreviewAudio:        api.memory.has("Video preview audio") ? api.memory.get("Video preview audio") : "No",
             ShowScanlines:                 api.memory.has("Show scanlines") ? api.memory.get("Show scanlines") : "No",

--- a/utils.js
+++ b/utils.js
@@ -306,6 +306,8 @@ function boxArt(data) {
     else {
       if (data.assets.boxFront != "")
         return data.assets.boxFront;
+      if (data.assets.poster != "")
+        return data.assets.poster;
       if (data.assets.screenshots[0] != "")
         return data.assets.screenshots[0];
     }

--- a/utils.js
+++ b/utils.js
@@ -304,6 +304,8 @@ function boxArt(data) {
     if (data.assets.boxFront.includes("/header.jpg")) 
       return steamBoxArt(data);
     else {
+      if (data.assets.boxFront != "")
+        return data.assets.boxFront;
       if (data.assets.screenshots[0] != "")
         return data.assets.screenshots[0];
     }


### PR DESCRIPTION
supersedes #24 if merged, this contains those changes as well

this pr adds a new setting "Use posters for grid" which uses the `assets.poster` from games for the grid instead of the logo/screenshot behavior

with the setting disabled (default/old behavior):
<img width="282" height="274" alt="image" src="https://github.com/user-attachments/assets/c3c2182b-3273-4faf-8757-c5775f0b6682" />

setting enabled (and poster asset provided):
<img width="262" height="262" alt="image" src="https://github.com/user-attachments/assets/8e4042c4-a251-442d-8d8b-411d9e0a819e" />

i would maintain my own fork but i dont think "a fork of a fork of a fork of a fork" is really catchy